### PR TITLE
Updated target syntax validation for Fastmail to prevent false positive results

### DIFF
--- a/mailcat.py
+++ b/mailcat.py
@@ -624,7 +624,7 @@ async def fastmail(target, req_session_fun) -> Dict:  # sanctions against Russia
     target = target.lower()
 
     # validate target syntax to prevent false positive results
-    match = re.search(r'^\w{3,40}$', target)
+    match = re.search(r'^[a-zA-Z]\w{2,40}$', target, re.ASCII)
 
     if not match:
         return result


### PR DESCRIPTION
Usernames have to start with a letter